### PR TITLE
Adding support for variable parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function applyDefaults (options, defaults) {
 
 function render (options, callback) {
 
-	var validationResult = tv4.validateResult(options, configSchema, null, true),
+	var validationResult = tv4.validateResult(options, configSchema, null),
 		projectionsMap = {
 			orthogonal: 'o',
 			perspective: 'p'
@@ -75,7 +75,7 @@ function render (options, callback) {
 	if (options.variables !== {})
 		for (key in options.variables)
 			if (options.variables.hasOwnProperty(key))
-				variablesCommand += key + '=' + options.variables[key] + ' '
+				variablesCommand += ' -D ' + key + '=' + options.variables[key] + ' '
 
 
 	shellCommand = [

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function render (options, callback) {
 	if (options.variables !== {})
 		for (key in options.variables)
 			if (options.variables.hasOwnProperty(key))
-				variablesCommand += ' -D ' + key + '=' + options.variables[key] + ' '
+				variablesCommand += '-D ' + key + '=' + options.variables[key] + ' '
 
 
 	shellCommand = [

--- a/test/cone.scad
+++ b/test/cone.scad
@@ -1,3 +1,5 @@
+height = 50;
+
 module cone() {
 	intersection() {
 		difference() {
@@ -13,7 +15,7 @@ module cone() {
 			}
 		}
 		translate([0, 0, 5])
-		cylinder(h = 50, r1 = 20, r2 = 5, center = true);
+		cylinder(h = height, r1 = 20, r2 = 5, center = true);
 	}
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -2,12 +2,22 @@ var nodeScad = require('../index.js'),
 	path = require('path'),
 	assert = require('assert'),
 	os = require('os'),
+	fs = require('fs'),
 	binaryPath = null
 
+var possibleBinaryPaths = [
+	'~/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD',
+	'/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD'
+	// Running on windows or Linux? What's a good path?
+]
 
-if (os.platform() === 'darwin')
-	binaryPath = '~/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD'
-
+// Find our OpenSCAD path
+for (var i in possibleBinaryPaths) {
+	if ( fs.existsSync( possibleBinaryPaths[i] ) ) {
+		binaryPath = possibleBinaryPaths[i];
+		break;
+	}
+}
 
 nodeScad.render(
 	{
@@ -49,6 +59,37 @@ nodeScad.renderFile(
 			throw error
 
 		expectedFileSize = 55235
+		actualFileSize = bufferData.toString().length
+
+		assert.equal(
+			actualFileSize,
+			expectedFileSize,
+			'Stl file has wrong size. ' +
+			'Expected ' + expectedFileSize +
+			' but got ' + actualFileSize
+		)
+	}
+)
+
+// Test for overridable paramters
+nodeScad.renderFile(
+	path.join(__dirname, 'cone.scad'),
+	{
+		binaryPath: binaryPath,
+		variables: {
+			height: 70,
+			robot: 10
+		}
+	},
+	function (error, bufferData) {
+
+		var expectedFileSize,
+			actualFileSize
+
+		if (error)
+			throw error
+
+		expectedFileSize = 66100
 		actualFileSize = bufferData.toString().length
 
 		assert.equal(

--- a/test/test.js
+++ b/test/test.js
@@ -78,7 +78,7 @@ nodeScad.renderFile(
 		binaryPath: binaryPath,
 		variables: {
 			height: 70,
-			robot: 10
+			anotherParamter: 10
 		}
 	},
 	function (error, bufferData) {


### PR DESCRIPTION
The 'banUnknownProperties' flag on tv4 seems too restrictive. I tried various other workarounds such as adding an empty properties definition to the schema under 'variables' but couldn't find a way to do with that that library.

This PR disables that flag and fixes the syntax for variables parameters (adding -D per http://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_OpenSCAD_in_a_command_line_environment) and adds a quick test for it.
